### PR TITLE
PSD-959 Update transport version to get accesslog bugfix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asecurityteam/settings v0.4.0
-	github.com/asecurityteam/transport v1.5.0
+	github.com/asecurityteam/transport v1.5.1
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/asecurityteam/settings v0.4.0 h1:L7fK4WqkvnvglBrfLBgp77LUDR2cxfSNWGFe
 github.com/asecurityteam/settings v0.4.0/go.mod h1:frhlF5kT7WvdiRX3eQlCOjSppbYUfxxjM9xKTvYjcGo=
 github.com/asecurityteam/transport v1.5.0 h1:hI4ABpKLf3iqX7JQDOCUz7CaEpmKCo5UaoD/zeSQLdU=
 github.com/asecurityteam/transport v1.5.0/go.mod h1:mLIn6qKYxZGBfUqzTizV6Ld831lcdLPz/amDmgOKCew=
+github.com/asecurityteam/transport v1.5.1 h1:4rH99bX+rniggAJEpRrpiByHTLYHFYQvJFSKs9be8S4=
+github.com/asecurityteam/transport v1.5.1/go.mod h1:mLIn6qKYxZGBfUqzTizV6Ld831lcdLPz/amDmgOKCew=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Update to the latest [transport](https://github.com/asecurityteam/transport) version to get the bugfix for the new accesslog `http.Transport` decorator.